### PR TITLE
support w4a8 weight_quantize

### DIFF
--- a/paddle/phi/infermeta/unary.cc
+++ b/paddle/phi/infermeta/unary.cc
@@ -6014,10 +6014,12 @@ void WeightQuantizeInferMeta(const MetaTensor& x,
     dim_out = std::vector<int64_t>({x_dims[1], x_dims[0]});
   } else if (algo == "weight_only_int4") {
     dim_out = std::vector<int64_t>({x_dims[1] / 2, x_dims[0]});
+  } else if (algo == "w4a8") {
+    dim_out = std::vector<int64_t>({x_dims[1], x_dims[0] / 2});
   } else {
     PADDLE_THROW(common::errors::InvalidArgument(
         "The algo must be in ['weight_only_int8', 'weight_only_int4', "
-        "'llm.int8'], but got[%s]",
+        "'llm.int8', 'w4a8'], but got[%s]",
         algo));
   }
   out->set_dims(common::make_ddim(dim_out));

--- a/paddle/phi/kernels/gpu/weight_quantize_kernel.cu
+++ b/paddle/phi/kernels/gpu/weight_quantize_kernel.cu
@@ -114,10 +114,17 @@ void WeightQuantizeKernel(const Context& dev_ctx,
                                 arch,
                                 algo);
 #endif
+  } else if (algo == "w4a8") {
+    weight_permute_gpu_nf4<Context>(dev_ctx,
+                                    x.data<int8_t>(),
+                                    out->data<int8_t>(),
+                                    weight_shape,
+                                    arch,
+                                    algo);
   } else {
     PADDLE_FATAL(
         "The algo must be in ['weight_only_int8', 'weight_only_int4', "
-        "'llm.int8'], but got[%s]",
+        "'llm.int8', 'w4a8'], but got[%s]",
         algo);
   }
 }
@@ -128,4 +135,5 @@ PD_REGISTER_KERNEL(weight_quantize,
                    ALL_LAYOUT,
                    phi::WeightQuantizeKernel,
                    phi::dtype::float16,
-                   phi::dtype::bfloat16) {}
+                   phi::dtype::bfloat16,
+                   int8_t) {}

--- a/paddle/phi/kernels/gpu/weight_quantize_kernel.cu
+++ b/paddle/phi/kernels/gpu/weight_quantize_kernel.cu
@@ -115,12 +115,12 @@ void WeightQuantizeKernel(const Context& dev_ctx,
                                 algo);
 #endif
   } else if (algo == "w4a8") {
-    weight_permute_gpu_nf4<Context>(dev_ctx,
-                                    x.data<int8_t>(),
-                                    out->data<int8_t>(),
-                                    weight_shape,
-                                    arch,
-                                    algo);
+    weight_permute_gpu_w4a8<Context>(dev_ctx,
+                                     x.data<int8_t>(),
+                                     out->data<int8_t>(),
+                                     weight_shape,
+                                     arch,
+                                     algo);
   } else {
     PADDLE_FATAL(
         "The algo must be in ['weight_only_int8', 'weight_only_int4', "

--- a/paddle/phi/kernels/impl/weight_quantize_kernel_gpu_impl.h
+++ b/paddle/phi/kernels/impl/weight_quantize_kernel_gpu_impl.h
@@ -479,7 +479,7 @@ void weight_quant_gpu(const GPUContext& dev_ctx,
 }
 
 // pack int8 weight to 2int4 int one int8
-__global__ void weight_permute_transpose_interleave_kernel_wnf4a8(
+__global__ void weight_permute_transpose_interleave_kernel_w4a8(
     const int8_t* input_data_ptr,
     int8_t* output_data_ptr,
     int numel,
@@ -501,20 +501,8 @@ __global__ void weight_permute_transpose_interleave_kernel_wnf4a8(
 
       int tid_div_16 = threadIdx.x / 16;
       int tid_mod_16 = threadIdx.x % 16;
-
       int src_offset = (tid_div_16 * permute_group + tid_mod_16) * total_n;
 
-/*
-src:                              dst:
-    rows: permute_group
-    cols: interleave
-          x0 y0 ...                     [x0, x16], [x1 x17], ...
-          x2 y2 ...                     [y0, y16], [y1 y17], ...
-          x1 y1
-          ...
-          x16 y16
-          ...
-*/
 #pragma unroll
       for (int idx = 0; idx < interleave; idx++) {
         const int8_t* src_ptr_2 = src_ptr_1 + idx;
@@ -533,12 +521,12 @@ src:                              dst:
 }
 
 template <typename GPUContext>
-void weight_permute_gpu_nf4(const GPUContext& dev_ctx,
-                            const int8_t* input_data,
-                            int8_t* output_data,
-                            const std::vector<int>& shape,
-                            const int32_t arch,
-                            const std::string& algo) {
+void weight_permute_gpu_w4a8(const GPUContext& dev_ctx,
+                             const int8_t* input_data,
+                             int8_t* output_data,
+                             const std::vector<int>& shape,
+                             const int32_t arch,
+                             const std::string& algo) {
   auto total_k = shape[0];
   auto total_n = shape[1];
   auto numel = total_k * total_n;
@@ -551,8 +539,7 @@ void weight_permute_gpu_nf4(const GPUContext& dev_ctx,
   if (arch > 70) {
     if (algo == "w4a8") {
       dim3 block_dim(32, block_size / 32);
-      weight_permute_transpose_interleave_kernel_wnf4a8<<<grid_size,
-                                                          block_dim>>>(
+      weight_permute_transpose_interleave_kernel_w4a8<<<grid_size, block_dim>>>(
           input_data, output_data, numel, total_k, total_n);
     }
   } else {

--- a/paddle/phi/kernels/impl/weight_quantize_kernel_gpu_impl.h
+++ b/paddle/phi/kernels/impl/weight_quantize_kernel_gpu_impl.h
@@ -478,4 +478,87 @@ void weight_quant_gpu(const GPUContext& dev_ctx,
   }
 }
 
+// pack int8 weight to 2int4 int one int8
+__global__ void weight_permute_transpose_interleave_kernel_wnf4a8(
+    const int8_t* input_data_ptr,
+    int8_t* output_data_ptr,
+    int numel,
+    int total_k,
+    int total_n) {
+  const int interleave = 4;
+  const int interleave_group = 64;
+  const int permute_group = 32;
+
+  for (int block_n = blockIdx.x; block_n < total_n / interleave;
+       block_n += gridDim.x) {
+    const int8_t* src_ptr = input_data_ptr + block_n * interleave;
+    int8_t* dst_ptr = output_data_ptr + block_n * interleave * total_k / 2;
+
+    for (int block_k = threadIdx.y; block_k < total_k / interleave_group;
+         block_k += blockDim.y) {
+      const int8_t* src_ptr_1 = src_ptr + block_k * interleave_group * total_n;
+      int8_t* dst_ptr_1 = dst_ptr + block_k * interleave_group * interleave / 2;
+
+      int tid_div_16 = threadIdx.x / 16;
+      int tid_mod_16 = threadIdx.x % 16;
+
+      int src_offset = (tid_div_16 * permute_group + tid_mod_16) * total_n;
+
+/*
+src:                              dst:
+    rows: permute_group
+    cols: interleave
+          x0 y0 ...                     [x0, x16], [x1 x17], ...
+          x2 y2 ...                     [y0, y16], [y1 y17], ...
+          x1 y1
+          ...
+          x16 y16
+          ...
+*/
+#pragma unroll
+      for (int idx = 0; idx < interleave; idx++) {
+        const int8_t* src_ptr_2 = src_ptr_1 + idx;
+        int8_t* dst_ptr_2 = dst_ptr_1 + idx * interleave_group / 2;
+
+        int8_t tmp0 = src_ptr_2[src_offset];
+        int8_t tmp1 = src_ptr_2[src_offset + permute_group / 2 * total_n];
+
+        int8_t packed_val = (tmp0 & 0x0f) | ((tmp1 & 0x0f) << 4);
+
+        int dst_offset = threadIdx.x;
+        dst_ptr_2[dst_offset] = packed_val;
+      }
+    }
+  }
+}
+
+template <typename GPUContext>
+void weight_permute_gpu_nf4(const GPUContext& dev_ctx,
+                            const int8_t* input_data,
+                            int8_t* output_data,
+                            const std::vector<int>& shape,
+                            const int32_t arch,
+                            const std::string& algo) {
+  auto total_k = shape[0];
+  auto total_n = shape[1];
+  auto numel = total_k * total_n;
+  auto gpu_config = phi::backends::gpu::GetGpuLaunchConfig1D(dev_ctx, numel, 1);
+  int grid_size = gpu_config.GetGridSize();
+  int block_size = gpu_config.GetBlockSize();
+  VLOG(2) << "weight_permute_gpu: total_k = " << total_k
+          << "total_n = " << total_n << "grid size = " << grid_size
+          << " block size = " << block_size;
+  if (arch > 70) {
+    if (algo == "w4a8") {
+      dim3 block_dim(32, block_size / 32);
+      weight_permute_transpose_interleave_kernel_wnf4a8<<<grid_size,
+                                                          block_dim>>>(
+          input_data, output_data, numel, total_k, total_n);
+    }
+  } else {
+    phi::errors::Unimplemented(
+        "The algo %s support need arch > 70, but got algo = %d.", algo, arch);
+  }
+}
+
 }  // namespace phi

--- a/python/paddle/nn/quant/quantized_linear.py
+++ b/python/paddle/nn/quant/quantized_linear.py
@@ -73,7 +73,7 @@ def weight_quantize(
     Args:
         x (Tensor): The input Tensor to be quantized, the data type is float16 or bfloat16.
         algo (str): The algo that is x will be apply, must be one of 'weight_only_int8',
-            'weight_only_int4' and 'llm.int8', default: 'weight_only_int8'.
+            'weight_only_int4', 'llm.int8' and 'w4a8', default: 'weight_only_int8'.
         arch (int): The compute arch for target device. For example, A100 is 80, v100 is 70, if you do not assign arch, we will get arch from your device, default: None.
         group_size (int): The group size for weight quantization. -1 stands for default per-channel mode. Currently only support 64 or 128.
 


### PR DESCRIPTION
支持w4a8的权重转换，与weight_only_int8/weight_only_int4共用同一个算子，新增algo=“w4a8"
